### PR TITLE
Temporary logo font change

### DIFF
--- a/404.html
+++ b/404.html
@@ -20,9 +20,8 @@ layout: default
 </section>
 
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/bulma/0.7.1/css/bulma.min.css" />
-<link href="https://fonts.googleapis.com/css?family=Do+Hyeon" rel="stylesheet" />
 <link rel="stylesheet" href="./css/landing.css" />
+{% include josefin-sans.html %}
 
 <script src="https://cdn.jsdelivr.net/npm/particles.js@2.0.0/particles.min.js" async></script>
-<script src="https://cdnjs.cloudflare.com/ajax/libs/modernizr/2.8.3/modernizr.min.js" async></script>
 <script src="./js/main.js" async></script>

--- a/_includes/josefin-sans.html
+++ b/_includes/josefin-sans.html
@@ -1,0 +1,1 @@
+<link href="https://fonts.googleapis.com/css?family=Josefin+Sans:700" rel="stylesheet">

--- a/css/landing.css
+++ b/css/landing.css
@@ -1,5 +1,5 @@
 :root {
-  --head: "Do Hyeon", sans-serif;
+  --head: "Josefin Sans", sans-serif;
   --grey: #5b5b5b;
   --bg1: #6ea8ff;
   --text: black;
@@ -13,20 +13,11 @@
   overflow: hidden;
 }
 
-#particles-js {
-  position: absolute;
-  top: 0;
-  width: 100%;
-  height: 100%;
-  background-image: url("");
-  background-repeat: no-repeat;
-  background-size: cover;
-  background-position: 50% 50%;
-  pointer-events: auto;
-}
-
-.title {
+.logo {
   font-family: var(--head);
+  text-rendering: optimizeLegibility;
+  text-transform: uppercase;
+  letter-spacing: -0.05em;
 }
 
 .subtitle {

--- a/css/particles.css
+++ b/css/particles.css
@@ -1,0 +1,11 @@
+#particles-js {
+  position: absolute;
+  top: 0;
+  width: 100%;
+  height: 100%;
+  background-image: url("");
+  background-repeat: no-repeat;
+  background-size: cover;
+  background-position: 50% 50%;
+  pointer-events: auto;
+}

--- a/index.html
+++ b/index.html
@@ -25,7 +25,6 @@ layout: default
 </section>
 
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/bulma/0.7.1/css/bulma.min.css" />
-<link href="https://fonts.googleapis.com/css?family=Do+Hyeon" rel="stylesheet" />
 <link rel="stylesheet" href="./css/landing.css" />
 <link rel="stylesheet" href="./css/particles.css" />
 

--- a/index.html
+++ b/index.html
@@ -9,8 +9,8 @@ layout: default
 <section class="hero is-fullheight is-overlay">
   <div class="hero-body">
     <div class="container has-text-centered">
-      <h1 class="title is-size-1 is-size-3-mobile">
-        <a href="https://github.com/immutability-io">{{ site.title }}</a>
+      <h1 class="title is-size-1 is-size-3-mobile logo">
+        <a href="https://github.com/immutability-io">IMMUTABILITY</a>
       </h1>
       <h2 class="subtitle">
         Coming soon
@@ -27,7 +27,8 @@ layout: default
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/bulma/0.7.1/css/bulma.min.css" />
 <link href="https://fonts.googleapis.com/css?family=Do+Hyeon" rel="stylesheet" />
 <link rel="stylesheet" href="./css/landing.css" />
+<link rel="stylesheet" href="./css/particles.css" />
 
+{% include josefin-sans.html %}
 <script src="https://cdn.jsdelivr.net/npm/particles.js@2.0.0/particles.min.js" async></script>
-<script src="https://cdnjs.cloudflare.com/ajax/libs/modernizr/2.8.3/modernizr.min.js" async></script>
 <script src="./js/main.js" async></script>

--- a/js/main.js
+++ b/js/main.js
@@ -15,10 +15,11 @@ g = {
 $particles = document.getElementById("particles-js");
 
 ready(function () {
-  // Fewer particles on mobiles
-  if (Modernizr.mq('only all and (max-width: 480px)')) {
-    g.value = 20
-  };
+  // Tone down the particles on mobiles
+  var w = Math.max(document.documentElement.clientWidth, window.innerWidth || 0);
+  if (w < 480) {
+    g.particles = 20
+  }
 
   // Particles.js by Vincent Garreau
   // https://github.com/VincentGarreau/particles.js/


### PR DESCRIPTION
- Now uses [Josefin Sans](https://fonts.google.com/specimen/Josefin+Sans) for the Immutability logo
  - Sifonn was the old one, but we'll want more webfont support (ideally SVG, but WOFF2 > WOFF > EOT > OTF would be preference order)
  - Josefin Sans is still a geometric sans-serif with the sharp "M"s
- Removes the Modernizr dependency, which was my lazy way of reducing particle counts for mobile viewports
- Also includes a particles CSS partial which I committed somewhat by mistake, but I'll be packaging the particles background as a drop-in `_includes` component
- [x] Removed the previous Do Hyeon font import for the 404 and index HTMLs

TODO

- Finish up moving the particles component JS/CSS/HTML into their own component
