### PR TITLE
Makefile changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 
 # Built Jekyll site
 _site
+.jekyll-metadata

--- a/Makefile
+++ b/Makefile
@@ -9,4 +9,12 @@ serve:
 		jekyll/jekyll \
 		jekyll serve
 
-.PHONY: serve
+spellcheck:
+	@echo ">> Spell checking..."
+	@misspell -error -source=text .
+
+clean:
+	@echo ">> Scrubbing..."
+	@rm -rv _site
+
+.PHONY: serve clean

--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,6 @@ spellcheck:
 
 clean:
 	@echo ">> Scrubbing..."
-	@rm -rv _site
+	@rm -rv _site .jekyll-metadata
 
 .PHONY: serve build clean

--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,16 @@ serve:
 		jekyll/jekyll \
 		jekyll serve
 
+build:
+	@echo ">> Building static pages..."
+	@docker run \
+		--interactive \
+		--rm \
+		--tty \
+		--volume "$(shell pwd):/srv/jekyll" \
+		jekyll/jekyll \
+		jekyll build -It
+
 spellcheck:
 	@echo ">> Spell checking..."
 	@misspell -error -source=text .
@@ -17,4 +27,4 @@ clean:
 	@echo ">> Scrubbing..."
 	@rm -rv _site
 
-.PHONY: serve clean
+.PHONY: serve build clean


### PR DESCRIPTION
- Adds `spellcheck`, `clean`, and `build` subcommands for testing the site locally
  - Spell checking uses [client9/misspell](https://github.com/client9/misspell) which really only checks Golang and Markdown-type files, but will be good to have for later